### PR TITLE
update-requirements.sh: point to upstream googlefonts/fontc, not anthrotype fork

### DIFF
--- a/update-requirements.sh
+++ b/update-requirements.sh
@@ -3,8 +3,6 @@
 # Download the requirements.txt file with pinned fontc version and SHA256 hashes
 # as specified in the 'VERSION' file.
 
-# Un-comment this and delete the fork's url when the upstream repo starts publishing releases
-# FONTC_REPO_URL="https://github.com/googlefonts/fontc"
-FONTC_REPO_URL="https://github.com/anthrotype/fontc"
+FONTC_REPO_URL="https://github.com/googlefonts/fontc"
 
 curl -LJo fontcExport.glyphsFileFormat/Contents/Resources/requirements.txt $FONTC_REPO_URL/releases/download/fontc-v$(<FONTC_VERSION)/requirements.txt


### PR DESCRIPTION
once fontc is published to crates.io and the googlefonts/fontc repository has some Github Releases published, the update-requirements.sh script can be set to point to the upstream repository URL, currently it's still pointing to my fork