### PR TITLE
display error dialog prompting user to force upgrade buggy Python plugin

### DIFF
--- a/fontcExport.glyphsFileFormat/Contents/Resources/plugin.py
+++ b/fontcExport.glyphsFileFormat/Contents/Resources/plugin.py
@@ -234,7 +234,18 @@ class FontcExport(FileFormatPlugin):
             "-r",
             os.path.join(self.pluginResourcesDirPath(), "requirements.txt"),
         ]
-        run_subprocess_in_macro_window(installCommand, check=True)
+        try:
+            run_subprocess_in_macro_window(installCommand, check=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                "\nThere is a known issue with the Glyphs Python plugin that "
+                "prevents `pip` from working correctly. This has been fixed in "
+                "the latest version of the Python plugin.\n"
+                "You can try to force the upgrade by going to: "
+                "Window -> Plugin Manager -> Modules, then click the red "
+                "'REMOVE' button next to the 'Python' plugin, then 'INSTALL' and "
+                "finally restart Glyphs app.\n"
+            ) from e
 
         assert os.path.exists(fontcPath), "fontc not found after installation"
         return fontcPath


### PR DESCRIPTION
the old Glyphs Python plugin had an issue with the pip command, which has now been fixed in the latest version of that plugin. The upgrade should happen automatically I believe, but in any case it's better to tell the user they can manually remove and reinstall the Python plugin to overcome the issue

see https://github.com/schriftgestalt/glyphs-packages/pull/146#issuecomment-2114733827

<img width="305" alt="Screenshot 2024-05-16 at 15 23 53" src="https://github.com/googlefonts/fontc-export-plugin/assets/6939968/ae599b98-b7e7-422e-85ee-cac31491f13f">
